### PR TITLE
Rename Api to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,13 @@ Thumbs.db
 .venv
 env/
 venv/
+venv27/
+venv36/
+venv37/
+venv38/
+venv35/
+venv34/
+venv3/
 ENV/
 env.bak/
 venv.bak/

--- a/.gitignore
+++ b/.gitignore
@@ -91,12 +91,12 @@ Thumbs.db
 env/
 venv/
 venv27/
+venv3/
 venv36/
 venv37/
 venv38/
 venv35/
 venv34/
-venv3/
 ENV/
 env.bak/
 venv.bak/

--- a/construct/__init__.py
+++ b/construct/__init__.py
@@ -8,4 +8,13 @@ __email__ = 'danielbradham@gmail.com'
 __url__ = 'https://github.com/construct-org/construct'
 
 
-from .api import Api, get_api, set_api
+from .constants import DEFAULT_API_NAME
+from . import api
+
+
+def API(name=DEFAULT_API_NAME, **kwargs):
+    '''Wrap api.API is a singleton'''
+
+    if name not in api._cache:
+        api._cache[name] = api.API(name, **kwargs)
+    return api._cache[name]

--- a/construct/path.py
+++ b/construct/path.py
@@ -8,7 +8,14 @@ from .constants import DEFAULT_PATHS
 
 class Path(list):
 
+    def __init__(self, path=None):
+        self._custom = bool(path)
+        if path:
+            self.extend(path)
+
     def load(self):
+        if self._custom:
+            return
         try:
             env_paths = os.environ['CONSTRUCT_PATH'].strip(os.pathsep)
             self.extend(env_paths.split(os.pathsep))

--- a/construct/path.py
+++ b/construct/path.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 import os
 
+from builtins import super
 from .utils import unipath
 from .constants import DEFAULT_PATHS
 
@@ -9,12 +10,13 @@ from .constants import DEFAULT_PATHS
 class Path(list):
 
     def __init__(self, path=None):
+        super().__init__()
         self._custom = bool(path)
-        if path:
-            self.extend(path)
+        self._custom_path = path
 
     def load(self):
         if self._custom:
+            self.extend(self._custom_path)
             return
         try:
             env_paths = os.environ['CONSTRUCT_PATH'].strip(os.pathsep)
@@ -24,7 +26,7 @@ class Path(list):
         self.extend(DEFAULT_PATHS)
 
     def unload(self):
-        self.clear()
+        self[:] = []
 
     def find(self, resource):
         for path in self:

--- a/construct/settings.py
+++ b/construct/settings.py
@@ -104,7 +104,7 @@ class Settings(dict):
             )
 
         self.update(**DEFAULT_SETTINGS)
-        self.file = USER_SETTINGS_FILE
+        self.file = unipath(self.path[-1], SETTINGS_FILE)
         potential_settings_file = find_in_paths(self.path, SETTINGS_FILE)
 
         if potential_settings_file:
@@ -130,7 +130,7 @@ class Settings(dict):
                 'Settings file not found.'
                 ' Writing default settings to ' + self.file
             )
-            restore_default_settings(USER_PATH)
+            restore_default_settings(self.path[-1])
 
         self.folder = os.path.dirname(self.file)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import sys
+import os
+import shutil
+
+from . import get_path
+from construct.settings import restore_default_settings
+import construct
+
+
+CUSTOM_USER_PATH = get_path('data', '.cons')
+
+
+def setup_module():
+    restore_default_settings(CUSTOM_USER_PATH)
+
+
+def teardown_module():
+    shutil.rmtree(CUSTOM_USER_PATH)
+
+
+def test_init():
+    '''initialize API'''
+
+    api = construct.API(__name__, path=[CUSTOM_USER_PATH])
+    assert api.settings
+
+
+def test_uninit():
+    '''uninitialize API'''
+
+    api = construct.API(__name__)
+    api.uninit()
+
+    assert not api.settings
+    assert not api.extensions


### PR DESCRIPTION
- Add simple API init and uninit tests.
- Allow passing path to API.
- Create default settings at last location in API.path. Typically the last
  location is ~/.construct unless you pass a custom path to API